### PR TITLE
Add service monitoring web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # NowServingNumber8000
+
+This repository contains a lightweight Python web application that lists running web services on a Raspberry Pi. The app runs on port 8000 and displays information such as port, uptime, CPU and memory usage for each detected service. Services listed are clickable so you can quickly open them in a new tab.
+
+## Setup
+
+1. Create and activate a virtual environment (optional but recommended):
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Start the server:
+   ```bash
+   python app.py
+   ```
+4. Visit `http://<your-ip>:8000` in your browser.
+
+The application attempts to determine if ports are forwarded to be accessible externally by making a connection to the device's public IP. This may not always be reliable depending on your network setup.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,138 @@
+import datetime
+import socket
+import time
+from typing import List, Dict
+
+import psutil
+import requests
+from flask import Flask, render_template_string, request
+
+app = Flask(__name__)
+
+# HTML template used to display the service table. Jinja2 syntax is used to
+# substitute values. Each service row includes a link to the running service.
+HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Running Services</title>
+    <style>
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <h1>Running Services</h1>
+    <table>
+        <tr>
+            <th>Name</th>
+            <th>Port</th>
+            <th>Protocol</th>
+            <th>Uptime</th>
+            <th>CPU %</th>
+            <th>RAM (MB)</th>
+            <th>Forwarded</th>
+        </tr>
+        {% for svc in services %}
+        <tr>
+            <td><a href="http://{{ host }}:{{ svc.port }}" target="_blank">{{ svc.name }}</a></td>
+            <td>{{ svc.port }}</td>
+            <td>{{ svc.protocol }}</td>
+            <td>{{ svc.uptime }}</td>
+            <td>{{ '{:.1f}'.format(svc.cpu) }}</td>
+            <td>{{ '{:.1f}'.format(svc.mem) }}</td>
+            <td>{{ 'Yes' if svc.forwarded else 'No' }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>
+"""
+
+
+def format_uptime(seconds: float) -> str:
+    """Convert seconds into a human readable H:M:S string."""
+    return str(datetime.timedelta(seconds=int(seconds)))
+
+
+def check_port_forwarding(public_ip: str, port: int, timeout: float = 1.0) -> bool:
+    """Attempt to connect to the given public IP and port to test forwarding."""
+    try:
+        with socket.create_connection((public_ip, port), timeout=timeout):
+            return True
+    except Exception:
+        return False
+
+
+def get_public_ip() -> str:
+    """Get the device's public IP using an external service."""
+    try:
+        response = requests.get("https://api.ipify.org", timeout=2)
+        response.raise_for_status()
+        return response.text.strip()
+    except Exception:
+        return ""
+
+
+def list_services() -> List[Dict]:
+    """Gather information about running services that are listening on a port."""
+    services = []
+    seen_ports = set()
+    public_ip = get_public_ip()
+
+    # Iterate over all network connections looking for listeners.
+    for conn in psutil.net_connections(kind="inet"):
+        if conn.status != psutil.CONN_LISTEN:
+            continue
+        if not conn.laddr:
+            continue
+        port = conn.laddr.port
+        # Avoid listing the same port multiple times.
+        if port in seen_ports:
+            continue
+        seen_ports.add(port)
+
+        pid = conn.pid
+        if pid is None:
+            continue
+        try:
+            proc = psutil.Process(pid)
+            name = proc.name()
+            create_time = proc.create_time()
+            uptime = format_uptime(time.time() - create_time)
+            cpu = proc.cpu_percent(interval=0.1)
+            mem = proc.memory_info().rss / (1024 * 1024)
+            protocol = "tcp" if conn.type == socket.SOCK_STREAM else "udp"
+            forwarded = False
+            if public_ip:
+                forwarded = check_port_forwarding(public_ip, port)
+            services.append({
+                "name": name,
+                "port": port,
+                "protocol": protocol,
+                "uptime": uptime,
+                "cpu": cpu,
+                "mem": mem,
+                "forwarded": forwarded,
+            })
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            # The process may have finished or we don't have permission.
+            continue
+
+    # Sort services by port for consistent ordering.
+    services.sort(key=lambda s: s["port"])
+    return services
+
+
+@app.route("/")
+def index():
+    host = request.host.split(":")[0]
+    services = list_services()
+    return render_template_string(HTML_TEMPLATE, services=services, host=host)
+
+
+if __name__ == "__main__":
+    # Run the web server on port 8000 accessible on all network interfaces.
+    app.run(host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+psutil
+requests


### PR DESCRIPTION
## Summary
- add minimal Flask app to list running services
- check port forwarding and show CPU/memory usage
- document setup in README
- ignore Python cache files

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python app.py` (manual run)


------
https://chatgpt.com/codex/tasks/task_e_68853902ab2c8328ac000c71acacd9ce