### PR TITLE
Allow custom port via command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NowServingNumber8000
 
-This repository contains a lightweight Python web application that lists running web services on a Raspberry Pi. The app runs on port 8000 and displays information such as port, uptime, CPU and memory usage for each detected service. Services listed are clickable so you can quickly open them in a new tab.
+This repository contains a lightweight Python web application that lists running web services on a Raspberry Pi. By default the app runs on port 8000 and displays information such as port, uptime, CPU and memory usage for each detected service. Services listed are clickable so you can quickly open them in a new tab.
 
 ## Setup
 
@@ -13,10 +13,10 @@ This repository contains a lightweight Python web application that lists running
    ```bash
    pip install -r requirements.txt
    ```
-3. Start the server:
+3. Start the server (optionally specify a custom port using `--port`):
    ```bash
-   python app.py
+   python app.py --port 8001
    ```
-4. Visit `http://<your-ip>:8000` in your browser.
+4. Visit `http://<your-ip>:<port>` in your browser (replace `<port>` with the number chosen, default is 8000).
 
 The application attempts to determine if ports are forwarded to be accessible externally by making a connection to the device's public IP. This may not always be reliable depending on your network setup.

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from typing import List, Dict
 import psutil
 import requests
 from flask import Flask, render_template_string, request
+import argparse  # used to parse command line options like --port
 
 app = Flask(__name__)
 
@@ -134,5 +135,17 @@ def index():
 
 
 if __name__ == "__main__":
-    # Run the web server on port 8000 accessible on all network interfaces.
-    app.run(host="0.0.0.0", port=8000)
+    parser = argparse.ArgumentParser(
+        description="Run the service listing web server"
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to run the server on (default: 8000)",
+    )
+    args = parser.parse_args()
+
+    # Run the web server accessible on all network interfaces using the
+    # specified port. Defaults to 8000 when no --port argument is provided.
+    app.run(host="0.0.0.0", port=args.port)


### PR DESCRIPTION
## Summary
- add `argparse` usage in `app.py` to read `--port`
- document custom port usage in `README`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68854fcda4a08328964a35c3367612ed