### PR TITLE
Enhance service names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NowServingNumber8000
 
-This repository contains a lightweight Python web application that lists running web services on a Raspberry Pi. By default the app runs on port 8000 and displays information such as port, uptime, CPU and memory usage for each detected service. Services listed are clickable so you can quickly open them in a new tab.
+This repository contains a lightweight Python web application that lists running web services on a Raspberry Pi. By default the app runs on port 8000 and displays information such as port, uptime, CPU and memory usage for each detected service. Services listed are clickable so you can quickly open them in a new tab. For Python-based services the table will also show the name of the script being executed rather than just `python`.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- show Python script name instead of python interpreter
- mention script name display in README

## Testing
- `python -m py_compile app.py`
- `timeout 3 python app.py --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_688551c43b508328ac7bcb271bbc045a