### PR TITLE
Add external service links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NowServingNumber8000
 
-This repository contains a lightweight Python web application that lists running web services on a Raspberry Pi. By default the app runs on port 8000 and displays information such as port, uptime, CPU and memory usage for each detected service. Services listed are clickable so you can quickly open them in a new tab. For Python-based services the table will also show the name of the script being executed rather than just `python`. The table additionally lists the full path from which each service was started.
+This repository contains a lightweight Python web application that lists running web services on a Raspberry Pi. By default the app runs on port 8000 and displays information such as port, uptime, CPU and memory usage for each detected service. Services listed are clickable so you can quickly open them in a new tab. For Python-based services the table will also show the name of the script being executed rather than just `python`. The table now includes a link to each service using the external address `http://193.237.136.211` with the service's port.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- remove the path column from the service table
- add a column linking to services via external IP
- document the new external link feature in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68855877f39083289d27e52eb67e06b7