### PR TITLE
Rename RPi script and add production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ This repository contains a lightweight Python web application that lists running
    ```bash
    pip install -r requirements.txt
    ```
-3. Start the server (optionally specify a custom port using `--port`):
+3. Start the server using the new script (optionally specify a custom port and `--production`):
    ```bash
-   python app.py --port 8001
+   python rpi_nsn8000.py --port 8001 --production
    ```
-4. Visit `http://<your-ip>:<port>` in your browser (replace `<port>` with the number chosen, default is 8000).
+4. Visit `http://<your-ip>:<port>` in your browser (replace `<port>` with the number chosen; default is 8000).
+
+Passing `--production` runs the app with the Waitress WSGI server which is suitable for long running deployments.
 
 The application attempts to determine if ports are forwarded to be accessible externally by making a connection to the device's public IP. This may not always be reliable depending on your network setup.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 psutil
 requests
+waitress

--- a/rpi_nsn8000.py
+++ b/rpi_nsn8000.py
@@ -7,7 +7,8 @@ import psutil
 import requests
 from flask import Flask, render_template_string, request, redirect, url_for
 import subprocess
-import argparse  # used to parse command line options like --port
+import argparse  # used to parse command line options like --port or --production
+from waitress import serve  # production-ready WSGI server
 
 app = Flask(__name__)
 
@@ -243,8 +244,19 @@ if __name__ == "__main__":
         default=8000,
         help="Port to run the server on (default: 8000)",
     )
+    parser.add_argument(
+        "--production",
+        action="store_true",
+        help="Run using the Waitress production server",
+    )
     args = parser.parse_args()
 
-    # Run the web server accessible on all network interfaces using the
-    # specified port. Defaults to 8000 when no --port argument is provided.
-    app.run(host="0.0.0.0", port=args.port)
+    # When --production is specified, use Waitress for a robust deployment.
+    # Otherwise fall back to Flask's built-in development server.
+    if args.production:
+        # Waitress serves the Flask app with better performance than the
+        # built-in development server and is safe for production use.
+        serve(app, host="0.0.0.0", port=args.port)
+    else:
+        # Flask development server is convenient for testing and debugging.
+        app.run(host="0.0.0.0", port=args.port)


### PR DESCRIPTION
## Summary
- rename `app.py` to `rpi_nsn8000.py`
- add `--production` option using Waitress server
- include Waitress in requirements
- document new script and production flag

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile rpi_nsn8000.py`

------
https://chatgpt.com/codex/tasks/task_e_6885d1343bd4832885f9ff35c200a3e8